### PR TITLE
Audio waveform

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,15 @@
   "dependencies": {
     "@hapi/boom": "^9.1.3",
     "axios": "^1.3.3",
+    "downsample": "^1.4.0",
     "futoin-hkdf": "^1.5.1",
     "libsignal": "git+https://github.com/adiwajshing/libsignal-node",
     "music-metadata": "^7.12.3",
     "node-cache": "^5.1.2",
+    "ogg-opus-decoder": "^1.5.3",
     "pino": "^7.0.0",
     "protobufjs": "^6.11.3",
+    "tsimportlib": "^0.0.3",
     "ws": "^8.0.0"
   },
   "peerDependencies": {

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -201,6 +201,9 @@ export type MiscMessageGenerationOptions = MinimalRelayOptions & {
     ephemeralExpiration?: number | string
     /** timeout for media upload to WA server */
     mediaUploadTimeoutMs?: number
+    /** building waveform in audio file */
+    mediaAudioWaveform?: boolean
+
 }
 export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions & {
 	userJid: string
@@ -218,6 +221,7 @@ export type MediaGenerationOptions = {
     mediaUploadTimeoutMs?: number
 
     options?: AxiosRequestConfig
+    mediaAudioWaveform?: boolean
 }
 export type MessageContentGenerationOptions = MediaGenerationOptions & {
 	getUrlInfo?: (text: string) => Promise<WAUrlInfo | undefined>

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -16,6 +16,8 @@ import { BaileysEventMap, DownloadableMessage, MediaConnInfo, MediaDecryptionKey
 import { BinaryNode, getBinaryNodeChild, getBinaryNodeChildBuffer, jidNormalizedUser } from '../WABinary'
 import { aesDecryptGCM, aesEncryptGCM, hkdf } from './crypto'
 import { generateMessageID } from './generics'
+import { LTTB } from 'downsample';
+import { dynamicImport } from 'tsimportlib';
 
 const getTmpFilesDirectory = () => tmpdir()
 
@@ -202,6 +204,91 @@ export async function getAudioDuration(buffer: Buffer | string | Readable) {
 	}
 
 	return metadata.format.duration
+}
+
+export async function getAudioWaveform(buffer: Buffer | string | Readable) {
+
+	const oggDecoderModule = await dynamicImport('ogg-opus-decoder', module) as typeof import('ogg-opus-decoder');
+	
+	const decoder = new oggDecoderModule.OggOpusDecoder()
+	await decoder.ready
+
+	let audioInfo: any | undefined = undefined
+
+	if (Buffer.isBuffer(buffer)) {
+		audioInfo = await decoder.decodeFile(buffer)
+	} else if(typeof buffer === 'string') {
+		const rStream = createReadStream(buffer)
+		const readAllChunks = new Promise<Buffer>((resolve, reject) => {
+			let buff = Buffer.alloc(0)
+			rStream.on('data', chunk => {
+				if (typeof chunk == "string") {
+					chunk = Buffer.from(chunk)
+				}
+				buff = Buffer.concat([buff, chunk])
+			})
+			rStream.on('end', () => {
+				rStream.close()
+				resolve(buff)
+			})
+			rStream.on('error', reject)
+		});		
+		audioInfo = await decoder.decodeFile(await readAllChunks)
+	} else {
+		// audioInfo = await decoder.decodeFile(buffer.)
+	}
+
+	const simpleMovingAverage = (values: Uint8Array, window: number = 5, arrayAverage: Uint8Array) => {
+		if (!values || values.length < window) {
+			return;
+		  }
+		  let indexResult = 0;
+
+		  let index = window - 1;
+		  const length = values.length + 1;
+
+		  while (++index < length) {
+			const windowSlice = values.slice(index - window, index);
+			const sum = windowSlice.reduce((prev, curr) => prev + curr, 0);
+			arrayAverage[++indexResult] = sum / window
+		  }
+	}
+	const normalizeWaveform = (values: Uint8Array) => {
+
+		const maxValue = Math.max(...values.map((v => v)))
+		const stepValue = 100 - maxValue;
+
+		for (let index = 0; index < values.length; index++) {
+			if (values[index] > 4) {
+				values[index] += stepValue
+			}
+		}		
+
+	}	
+
+	if (audioInfo && audioInfo.channelData.length >= 1) {
+		const wave = [ ... audioInfo.channelData[0].map((a: any) => a).filter((a: any) => a >= 0) ];
+		
+		const ampDownsampled: number[] = [];
+		
+		const downsampled = LTTB(wave.map((value, index) => [index, Math.round(value*100)]), 64);
+		for (let index = 0; index < downsampled.length; index++) {			
+			const element = downsampled[index];
+			ampDownsampled.push(Math.round(element[1]));
+		}
+
+		const waveform = new Uint8Array(ampDownsampled);
+		normalizeWaveform(waveform);
+		
+		const waveFormAverage = new Uint8Array(waveform.length);
+
+		simpleMovingAverage(waveform, 3, waveFormAverage);
+		normalizeWaveform(waveFormAverage);
+		
+		
+		return waveFormAverage;
+	}
+
 }
 
 export const toReadable = (buffer: Buffer) => {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -187,7 +187,9 @@ export const prepareWAMessageMedia = async(
 
 				if(requiresDurationComputation) {
 					uploadData.seconds = await getAudioDuration(bodyPath!)
-					uploadData.waveform = await getAudioWaveform(bodyPath!)
+					if (options.mediaAudioWaveform) {
+						uploadData.waveform = await getAudioWaveform(bodyPath!)
+					}
 					logger?.debug({ uploadData }, 'computed audio duration')
 				}
 			} catch(error) {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -26,7 +26,7 @@ import {
 import { isJidGroup, jidNormalizedUser } from '../WABinary'
 import { sha256 } from './crypto'
 import { generateMessageID, getKeyAuthor, unixTimestampSeconds } from './generics'
-import { downloadContentFromMessage, encryptedStream, generateThumbnail, getAudioDuration, MediaDownloadOptions } from './messages-media'
+import { downloadContentFromMessage, encryptedStream, generateThumbnail, getAudioDuration, getAudioWaveform, MediaDownloadOptions } from './messages-media'
 
 type MediaUploadData = {
 	media: WAMediaUpload
@@ -39,6 +39,7 @@ type MediaUploadData = {
 	mimetype?: string
 	width?: number
 	height?: number
+	waveform?: Uint8Array
 }
 
 const MIMETYPE_MAP: { [T in MediaType]?: string } = {
@@ -186,7 +187,8 @@ export const prepareWAMessageMedia = async(
 
 				if(requiresDurationComputation) {
 					uploadData.seconds = await getAudioDuration(bodyPath!)
-					logger?.debug('computed audio duration')
+					uploadData.waveform = await getAudioWaveform(bodyPath!)
+					logger?.debug({ uploadData }, 'computed audio duration')
 				}
 			} catch(error) {
 				logger?.warn({ trace: error.stack }, 'failed to obtain extra info')


### PR DESCRIPTION
This PR add support: waveform in audio messages.

<img width="418" alt="image" src="https://user-images.githubusercontent.com/13971947/233382413-72597d16-705e-4928-9e3f-64fe84d804d9.png">

```node
await sock.sendMessage('123456@s.whatsapp.net', {
	audio: { url: 'https://media.amazonaws.com/audio.ogg' },
	ptt: true
}, { mediaAudioWaveform: true })
```